### PR TITLE
Potential fix for code scanning alert no. 356: Code injection

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -46,12 +46,14 @@ jobs:
 
       - name: Get changed add-ons
         id: changed_addons
+        env:
+          CHANGED_FILES: ${{ steps.changed_files.outputs.all }}
         run: |
           declare -a changed_addons
           for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
+            if [[ "$CHANGED_FILES" =~ $addon ]]; then
               for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
+                  if [[ "$CHANGED_FILES" =~ $addon/$file ]]; then
                     if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
                       changed_addons+=("\"${addon}\",");
                     fi


### PR DESCRIPTION
Potential fix for [https://github.com/BigThunderSR/homeassistant-addons-bigthundersr/security/code-scanning/356](https://github.com/BigThunderSR/homeassistant-addons-bigthundersr/security/code-scanning/356)

To fix the code injection issue, we need to set the untrusted input value of the expression `${{ steps.changed_files.outputs.all }}` to an intermediate environment variable and then use the environment variable using the native syntax of the shell/script interpreter. This will prevent any potential code injection attacks.

1. Define an environment variable to hold the value of `${{ steps.changed_files.outputs.all }}`.
2. Use the environment variable within the shell script instead of directly using `${{ steps.changed_files.outputs.all }}`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
